### PR TITLE
Aero performance map changes

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -14811,7 +14811,8 @@ jonas.jepsen@dlr.de
 										the &lt;angleOfAttack&gt; is iterated automatically, so that
 										the given lift coefficient (C
 										<xsd:subscript>Fz</xsd:subscript>
-										) is met.
+										) is met. If a &lt;targetLiftCoefficient&gt; is selected, the
+                    corresponding &lt;angleOfAttack&gt; may be placed here, as well.
 									</ddue:para>
 								</ddue:content>
 							</ddue:section>
@@ -14979,11 +14980,19 @@ jonas.jepsen@dlr.de
 								<xsd:documentation>Angle of attack</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
-						<xsd:element name="targetLiftCoefficient" type="doubleBaseType">
-							<xsd:annotation>
-								<xsd:documentation>Target Lift Coefficient</xsd:documentation>
-							</xsd:annotation>
-						</xsd:element>
+						<xsd:sequence>
+							<xsd:element name="targetLiftCoefficient" type="doubleBaseType">
+								<xsd:annotation>
+									<xsd:documentation>Target Lift Coefficient</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+							<xsd:element minOccurs="0" name="angleOfAttack" type="doubleBaseType">
+								<xsd:annotation>
+									<xsd:documentation>Angle of attack corresponding to target lift
+										coefficient</xsd:documentation>
+								</xsd:annotation>
+							</xsd:element>
+						</xsd:sequence>
 					</xsd:choice>
 					<xsd:element minOccurs="0" name="quasiSteadyRotation" type="quasiSteadyRotationType"/>
 					<xsd:element minOccurs="0" name="controlSurfaces" type="controlSurfaceDeflectionsType"/>
@@ -21253,12 +21262,12 @@ jonas.jepsen@dlr.de
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
 				<xsd:all>
-					<xsd:element minOccurs="0" name="wingUID" type="stringBaseType">
+					<xsd:element minOccurs="0" name="fuselageUID" type="stringBaseType">
 						<xsd:annotation>
-							<xsd:documentation>Reference to a wing; required, if separate
-								transition definitions for each wing are used. If missing,
-								transition definitions are the same for all wings. If used, only
-								the specified wings are calculated</xsd:documentation>
+							<xsd:documentation>Reference to a fuselage; required, if separate
+								transition definitions for each fuselage are used. If missing,
+								transition definitions are the same for all fuselages. If used, only
+								the specified fuselages are calculated</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
 					<xsd:element name="relativeTransitionLocation" type="doubleBaseType">

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -54,10 +54,10 @@ jonas.jepsen@dlr.de
                             <ddue:section>
                                 <ddue:title>2. Coordinate Systems</ddue:title>
                                 <ddue:content>
-                                    <ddue:para>Coordinate systems are a regular cause for ambiguous interpretation of data. In CPACS only the CPACS-coordinate system is valid. The following paragraphs outline the determination to known coordinate systems.</ddue:para>
+                                    <ddue:para>Coordinate systems are a regular cause for ambiguous interpretation of data. In CPACS, mostly the CPACS-coordinate system is used. The following paragraphs outline the determination to known coordinate systems.</ddue:para>
                                     <ddue:para>The CPACS coordinate system is the coordinate system identified by TIGL, CPACS's geometric library. It is a right-handed coordinate system. If an aircraft is defined in the CPACS coordinate system it will usually follow the directions listed in the table below.</ddue:para>
                                     <ddue:para>Therefore, the CPACS coordinate system can be confused with the body-fixed coordinate system. While often the CPACS coordinate system and the body-fixed coordinate system overlap, this must not always be true. Several definitions for body-fixed coordinate systems exist (x-axis through nose and tail, x-axis perpendicular to nose plane). For non-symmetric aircraft, body-fixed coordinate systems become even more complicated. Hence, analysis tools should stick to the CPACS-Coordinate system. It remains to the designer to model the geometry accordingly.</ddue:para>
-                                    <ddue:para>The CPACS coordinate system does not rotate with flow. Hence, aerodynamic calculations do rotate their flow relative to the CPACS-coordinate system. If not stated explicitly different, e.g. for target lift-coefficients, results are returned in the CPACS coordinate system, i.e. the cfx-coefficient is parrallel to the CPACS x-Coordinate, regardless of the way the geometry is defined.</ddue:para>
+                                    <ddue:para>The CPACS coordinate system does not rotate with flow. Aerodynamic coefficients in &lt;aeroDataSetsForLoads&gt; are specified in CPACS coordinates, i.e. the cfx-coefficient is parrallel to the CPACS x-Coordinate, regardless of the way the geometry is defined. On the other hand, aerodynamic performance maps are specified in the aerodynamic coordinate system (see below). They can be distinguished by the trailing 'Aero' in the coefficient names (e.g. &lt;cfxAero&gt;).</ddue:para>
                                     <ddue:para>The following table gives an "best-practice" advice on how to locate a geometry within CPACS. Different approaches are, of course, valid as well.</ddue:para>
                                     <ddue:table>
                                         <ddue:row>
@@ -87,11 +87,15 @@ jonas.jepsen@dlr.de
                                             <ddue:entry>from landing gear to tip of vertical tailplane</ddue:entry>
                                         </ddue:row>
                                     </ddue:table>
+                                    <ddue:para>Coming from the CPACS coordinate system, the aerodynamic coordinate system is defined (according to german LN 9300) by roation around two angles: Angle of attack (alpha) and angle of sideslip (beta).
+                                      Alpha and Beta are defined from aerodynamic to CPACS coordinate system, so the explanation for the way from CPACS to aerodynamic ccordinate system uses (minus alpha) and (minus beta). 
+                                      (Minus Alpha) is a rotation angle around the CPACS y-axis from CPACS axis to an intermediate coordinate system (A positive sign of alpha means that the flow comes upwards from below).
+                                      (Minus Beta is the angle around the intermediate system's z-axis from that intermediate system to the aerodynamic system (A positive sign of beat means that the flow comes from the right (starboard) side.</ddue:para>
                                     <ddue:para>The following pictures give an example for a geometry that is defined in alignment with the CPACS coordinate system, i.e. the body coordinate system overlaps with the CPACS coordinate system.</ddue:para>
                                     <ddue:mediaLink>
                                         <ddue:image xlink:href="cosys01"/>
                                     </ddue:mediaLink>
-                                    <ddue:para>The aerodynamic analysis is relative to the CPACS coordinate system. That is, the angle of attack is represented by the dashed orange line. Results of the aerodynamic calculation are given in the CPACS coordinate system.</ddue:para>
+                                    <ddue:para>The aerodynamic analysis is relative to the CPACS coordinate system. That is, the angle of attack is represented by the dashed orange line. Results of the aerodynamic calculation are given in the CPACS coordinate system (loadcases) or in the aerodynamic coordinate system (aero performance maps). Coefficients in the aerodynamic coordinate system are named &lt;cf?Aero&gt; or &lt;cm?Aero&gt;.</ddue:para>
                                     <ddue:mediaLink>
                                         <ddue:image xlink:href="cosys02"/>
                                     </ddue:mediaLink>
@@ -103,7 +107,7 @@ jonas.jepsen@dlr.de
                                     <ddue:mediaLink>
                                         <ddue:image xlink:href="cosys2"/>
                                     </ddue:mediaLink>
-                                    <ddue:para>Again, the aerodynamic analysis is relative to the CPACS coordinate system. That is, the angle of attack is represented by the dashed orange line. Results of the aerodynamic calculation are given in the CPACS coordinate system.</ddue:para>
+                                    <ddue:para>Again, the aerodynamic analysis is relative to the CPACS coordinate system. That is, the angle of attack is represented by the dashed orange line. Results of the aerodynamic calculation are given in the CPACS coordinate system (loadcases) or in the aerodynamic coordinate system (aero performance maps). Coefficients in the aerodynamic coordinate system are named &lt;cf?Aero&gt; or &lt;cm?Aero&gt;.</ddue:para>
                                 </ddue:content>
                             </ddue:section>
                             <ddue:section>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -2832,19 +2832,32 @@ jonas.jepsen@dlr.de
 										This type contains data for the aerodynamic performance map
 										computations. In
 										<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
-										mode no further input is required here. But it is possible to
+										mode, only the UID of the aero performance map for computation
+										is required here. Furthermore, it is possible to
 										specify a quasiSteadyRotation node to switch on the
 										computation of damping derivatives. A list of control surface
 										UIDs further switches on the computation of delta-performance
 										maps for each of these control surfaces. In
 										<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 										mode, the parameter vectors for the performance map
-										computations have to be specified here.
+										computations, and optionally the quasi steady rotation values,
+										have to be specified here.
 									</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
 								<ddue:title>1.
+									&lt;aeroPerformanceMapUID&gt; (mandatory in
+									<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
+									mode)
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>The UID, referring to the aero performance map to
+										be computed.</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>2.
 									&lt;positiveQuasiSteadyRotation&gt; (optional in
 									<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
 									mode)
@@ -2856,12 +2869,12 @@ jonas.jepsen@dlr.de
 										is performed and used (together with the reference compuation
 										without any rotation) to derive the damping derivatives. This
 										node itself switches on the computation of negative damping
-										derivatives. IIf there are no subnodes, the positive defaults
+										derivatives. If there are no subnodes, the positive defaults
 										are used.</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>2.
+								<ddue:title>3.
 									&lt;negativeQuasiSteadyRotation&gt; (optional in
 									<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
 									mode)
@@ -2878,7 +2891,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>3.
+								<ddue:title>4.
 									&lt;controlSurfaceUID&gt; (optional in
 									<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
 									mode)
@@ -2890,7 +2903,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>4.
+								<ddue:title>5.
 									&lt;machNumber&gt; (mandatory in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -2902,31 +2915,31 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>5.
-									&lt;reynoldsNumber&gt; (mandatory in
-									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
-									mode)
-								</ddue:title>
-								<ddue:content>
-									<ddue:para>A vector of semicolon-separated values, specifying
-										all the Reynolds numbers being used to create the aerodynamic
-										performance map (Reynolds number dimension)</ddue:para>
-								</ddue:content>
-							</ddue:section>
-							<ddue:section>
 								<ddue:title>6.
-									&lt;angleOfYaw&gt; (mandatory in
+									&lt;altitude&gt; (mandatory in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
 								</ddue:title>
 								<ddue:content>
 									<ddue:para>A vector of semicolon-separated values, specifying
-										all the angles of yaw being used to create the aerodynamic
-										performance map (Angle of yaw dimension)</ddue:para>
+										all the altitudes being used to create the aerodynamic
+										performance map (altitude dimension)</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
 								<ddue:title>7.
+									&lt;angleOfSideslip&gt; (mandatory in
+									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
+									mode)
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>A vector of semicolon-separated values, specifying
+										all the angles of sideslip being used to create the aerodynamic
+										performance map (Angle of sideslip dimension)</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>8.
 									&lt;angleOfAttack&gt; (mandatory in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -2938,7 +2951,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>8.
+								<ddue:title>9.
 									&lt;positiveQuasiSteadyRotation&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -2959,7 +2972,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>9.
+								<ddue:title>10.
 									&lt;negativeQuasiSteadyRotation&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -2980,7 +2993,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>10.
+								<ddue:title>11.
 									&lt;controlSurfaces&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -3001,6 +3014,12 @@ jonas.jepsen@dlr.de
 			<xsd:extension base="complexBaseType">
 				<xsd:choice>
 					<xsd:sequence>
+						<xsd:element name="aeroPerformanceMapUID" type="stringUIDBaseType">
+							<xsd:annotation>
+								<xsd:documentation>Specification of the aero performance map to be computed
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
 						<xsd:element minOccurs="0" name="positiveQuasiSteadyRotation" type="quasiSteadyRotationType"/>
 						<xsd:element minOccurs="0" name="negativeQuasiSteadyRotation" type="quasiSteadyRotationType"/>
 						<xsd:element maxOccurs="unbounded" minOccurs="0" name="controlSurfaceUID" type="stringUIDBaseType">
@@ -3014,22 +3033,22 @@ jonas.jepsen@dlr.de
 					<xsd:sequence>
 						<xsd:element name="machNumber" type="stringVectorBaseType">
 							<xsd:annotation>
-								<xsd:documentation>Mach Number</xsd:documentation>
+								<xsd:documentation>Vector with Mach Numbers for computation</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
-						<xsd:element name="reynoldsNumber" type="stringVectorBaseType">
+						<xsd:element name="altitude" type="stringVectorBaseType">
 							<xsd:annotation>
-								<xsd:documentation>Reynolds Number</xsd:documentation>
+								<xsd:documentation>Vector with altitudes for computation</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
-						<xsd:element name="angleOfYaw" type="stringVectorBaseType">
+						<xsd:element name="angleOfSideslip" type="stringVectorBaseType">
 							<xsd:annotation>
-								<xsd:documentation>Yaw angle</xsd:documentation>
+								<xsd:documentation>Vector of angles of sideslip for computation</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 						<xsd:element name="angleOfAttack" type="stringVectorBaseType">
 							<xsd:annotation>
-								<xsd:documentation>Angle of attack</xsd:documentation>
+								<xsd:documentation>Vector of angles of attack for computation</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 						<xsd:element minOccurs="0" name="positiveQuasiSteadyRotation" type="quasiSteadyRotationType"/>
@@ -19568,6 +19587,15 @@ jonas.jepsen@dlr.de
 							</ddue:section>
 							<ddue:section>
 								<ddue:title>3.
+									&lt;technologyFactor&gt;
+									<ddue:legacyItalic>(optional)</ddue:legacyItalic>
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>Additional factor for calibrating the results.</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>4.
 									&lt;polynomialCoefficients&gt;
 									<ddue:legacyItalic>(mandatory)</ddue:legacyItalic>
 								</ddue:title>
@@ -19594,6 +19622,12 @@ jonas.jepsen@dlr.de
 					<xsd:element minOccurs="0" name="turbulentFormFactor" type="doubleBaseType">
 						<xsd:annotation>
 							<xsd:documentation>Form Factor for the turbulent wing region
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="technologyFactor" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Technology factor
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
@@ -19847,7 +19881,8 @@ jonas.jepsen@dlr.de
 										This type contains data for the aerodynamic performance map
 										computations with HandbookAero. In
 										<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
-										mode no further input is required here. But it is possible to
+										mode, only the UID of the aero performance map for computation
+										is required here. Furthermore, it is possible to
 										specify a quasiSteadyRotation node to switch on the
 										computation of damping derivatives. A list of control surface
 										UIDs further switches on the computation of delta-performance
@@ -19863,6 +19898,17 @@ jonas.jepsen@dlr.de
 							</ddue:section>
 							<ddue:section>
 								<ddue:title>1.
+									&lt;aeroPerformanceMapUID&gt; (mandatory in
+									<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
+									mode)
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>The UID, referring to the aero performance map to
+										be computed.</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>2.
 									&lt;positiveQuasiSteadyRotation&gt; (optional in
 									<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
 									mode)
@@ -19879,7 +19925,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>2.
+								<ddue:title>3.
 									&lt;negativeQuasiSteadyRotation&gt; (optional in
 									<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
 									mode)
@@ -19896,7 +19942,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>3.
+								<ddue:title>4.
 									&lt;controlSurfaceUID&gt; (optional in
 									<ddue:legacyItalic>Framework integration</ddue:legacyItalic>
 									mode)
@@ -19908,7 +19954,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>4.
+								<ddue:title>5.
 									&lt;machNumber&gt; (mandatory in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -19920,31 +19966,31 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>5.
-									&lt;reynoldsNumber&gt; (mandatory in
-									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
-									mode)
-								</ddue:title>
-								<ddue:content>
-									<ddue:para>A vector of semicolon-separated values, specifying
-										all the Reynolds numbers being used to create the aerodynamic
-										performance map (Reynolds number dimension)</ddue:para>
-								</ddue:content>
-							</ddue:section>
-							<ddue:section>
 								<ddue:title>6.
-									&lt;angleOfYaw&gt; (mandatory in
+									&lt;altitude&gt; (mandatory in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
 								</ddue:title>
 								<ddue:content>
 									<ddue:para>A vector of semicolon-separated values, specifying
-										all the angles of yaw being used to create the aerodynamic
-										performance map (Angle of yaw dimension)</ddue:para>
+										all the altitudes being used to create the aerodynamic
+										performance map (altitude dimension)</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
 								<ddue:title>7.
+									&lt;angleOfSideslip&gt; (mandatory in
+									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
+									mode)
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>A vector of semicolon-separated values, specifying
+										all the angles of sideslip being used to create the aerodynamic
+										performance map (Angle of sideslip dimension)</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>8.
 									&lt;angleOfAttack&gt; (mandatory in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -19956,8 +20002,8 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>8.
-									&lt;cfx&gt; (optional in
+								<ddue:title>9.
+									&lt;cfxAero&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
 								</ddue:title>
@@ -19971,8 +20017,8 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>9.
-									&lt;cfy&gt; (optional in
+								<ddue:title>10.
+									&lt;cfyAero&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
 								</ddue:title>
@@ -19986,8 +20032,8 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>10.
-									&lt;cfz&gt; (optional in
+								<ddue:title>11.
+									&lt;cfzAero&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
 								</ddue:title>
@@ -20001,8 +20047,8 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>11.
-									&lt;cmx&gt; (optional in
+								<ddue:title>12.
+									&lt;cmxAero&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
 								</ddue:title>
@@ -20016,8 +20062,8 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>12.
-									&lt;cmy&gt; (optional in
+								<ddue:title>13.
+									&lt;cmyAero&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
 								</ddue:title>
@@ -20031,8 +20077,8 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>13.
-									&lt;cmz&gt; (optional in
+								<ddue:title>14.
+									&lt;cmzAero&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
 								</ddue:title>
@@ -20046,7 +20092,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>14.
+								<ddue:title>15.
 									&lt;positiveQuasiSteadyRotation&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -20067,7 +20113,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>15.
+								<ddue:title>16.
 									&lt;negativeQuasiSteadyRotation&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -20088,7 +20134,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>16.
+								<ddue:title>17.
 									&lt;dampingDerivatives&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -20099,7 +20145,7 @@ jonas.jepsen@dlr.de
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>16.
+								<ddue:title>18.
 									&lt;controlSurfaces&gt; (optional in
 									<ddue:legacyItalic>Toolwrapper input</ddue:legacyItalic>
 									mode)
@@ -20122,46 +20168,48 @@ jonas.jepsen@dlr.de
 			<xsd:extension base="complexBaseType">
 				<xsd:choice>
 					<xsd:sequence>
+						<xsd:element name="aeroPerformanceMapUID" type="stringUIDBaseType">
+							<xsd:annotation>
+								<xsd:documentation>Specification of the aero performance map to be computed
+								</xsd:documentation>
+							</xsd:annotation>
+						</xsd:element>
 						<xsd:element minOccurs="0" name="positiveQuasiSteadyRotation" type="quasiSteadyRotationType"/>
 						<xsd:element minOccurs="0" name="negativeQuasiSteadyRotation" type="quasiSteadyRotationType"/>
 						<xsd:element maxOccurs="unbounded" minOccurs="0" name="controlSurfaceUID" type="stringBaseType">
 							<xsd:annotation>
 								<xsd:documentation>Specification of control surfaces, for which
-									additional delta-polars shall be computed</xsd:documentation>
+									additional delta-performance maps shall be computed</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 					</xsd:sequence>
 					<xsd:sequence>
 						<xsd:element name="machNumber" type="stringVectorBaseType">
 							<xsd:annotation>
-								<xsd:documentation>Vector with Mach Numbers for computation
-								</xsd:documentation>
+								<xsd:documentation>Vector with Mach Numbers for computation</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
-						<xsd:element name="reynoldsNumber" type="stringVectorBaseType">
+						<xsd:element name="altitude" type="stringVectorBaseType">
 							<xsd:annotation>
-								<xsd:documentation>Vector of Reynolds Numbers for computation
-								</xsd:documentation>
+								<xsd:documentation>Vector with altitudes for computation</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
-						<xsd:element name="angleOfYaw" type="stringVectorBaseType">
+						<xsd:element name="angleOfSideslip" type="stringVectorBaseType">
 							<xsd:annotation>
-								<xsd:documentation>Vector of yaw angles for computation
-								</xsd:documentation>
+								<xsd:documentation>Vector of angles of sideslip for computation</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 						<xsd:element name="angleOfAttack" type="stringVectorBaseType">
 							<xsd:annotation>
-								<xsd:documentation>Vector of angles of attack for computation
-								</xsd:documentation>
+								<xsd:documentation>Vector of angles of attack for computation</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
-						<xsd:element minOccurs="0" name="cfx" type="stringArrayBaseType"/>
-						<xsd:element minOccurs="0" name="cfy" type="stringArrayBaseType"/>
-						<xsd:element minOccurs="0" name="cfz" type="stringArrayBaseType"/>
-						<xsd:element minOccurs="0" name="cmx" type="stringArrayBaseType"/>
-						<xsd:element minOccurs="0" name="cmy" type="stringArrayBaseType"/>
-						<xsd:element minOccurs="0" name="cmz" type="stringArrayBaseType"/>
+						<xsd:element minOccurs="0" name="cfxAero" type="stringArrayBaseType"/>
+						<xsd:element minOccurs="0" name="cfyAero" type="stringArrayBaseType"/>
+						<xsd:element minOccurs="0" name="cfzAero" type="stringArrayBaseType"/>
+						<xsd:element minOccurs="0" name="cmxAero" type="stringArrayBaseType"/>
+						<xsd:element minOccurs="0" name="cmyAero" type="stringArrayBaseType"/>
+						<xsd:element minOccurs="0" name="cmzAero" type="stringArrayBaseType"/>
 						<xsd:element minOccurs="0" name="positiveQuasiSteadyRotation" type="quasiSteadyRotationType"/>
 						<xsd:element minOccurs="0" name="negativeQuasiSteadyRotation" type="quasiSteadyRotationType"/>
 						<xsd:element minOccurs="0" name="dampingDerivatives" type="dampingDerivativesRatesType"/>
@@ -20267,12 +20315,15 @@ jonas.jepsen@dlr.de
 								</ddue:title>
 								<ddue:content>
 									<ddue:para>
-										Detail level of handbookAero logging. There are three options
+										Detail level of handbookAero logging. There are 6 options
 										available:
 										<ddue:list class="bullet">
-											<ddue:listItem>0: Minimum logging</ddue:listItem>
-											<ddue:listItem>1: Detailed logging</ddue:listItem>
-											<ddue:listItem>2: Very detailed logging</ddue:listItem>
+											<ddue:listItem>0: Input and cases only)</ddue:listItem>
+											<ddue:listItem>1: Input, cases and total coefficients</ddue:listItem>
+											<ddue:listItem>2: Input, cases and coefficients down to component level</ddue:listItem>
+											<ddue:listItem>3: Input, cases and coefficients down to strip level</ddue:listItem>
+											<ddue:listItem>4: Input, cases and coefficients down to sub-strip level</ddue:listItem>
+											<ddue:listItem>5: Input, cases and coefficients in all levels and computation details</ddue:listItem>
 										</ddue:list>
 									</ddue:para>
 								</ddue:content>
@@ -20913,6 +20964,15 @@ jonas.jepsen@dlr.de
 							</ddue:section>
 							<ddue:section>
 								<ddue:title>4.
+									&lt;technologyFactor&gt;
+									<ddue:legacyItalic>(optional)</ddue:legacyItalic>
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>Additional factor for calibrating the results.</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>5.
 									&lt;polynomialCoefficients&gt;
 									<ddue:legacyItalic>(mandatory)</ddue:legacyItalic>
 								</ddue:title>
@@ -20946,6 +21006,12 @@ jonas.jepsen@dlr.de
 					<xsd:element minOccurs="0" name="turbulentFormFactor" type="doubleBaseType">
 						<xsd:annotation>
 							<xsd:documentation>Form Factor for the turbulent wing region
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="technologyFactor" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Technology factor
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
@@ -21033,16 +21099,28 @@ jonas.jepsen@dlr.de
 										factors for additional pressure drag due to viscous
 										separation. The flat plate is computed including
 										laminar-turbulent transition, with the transition position as
-										polynomial function of the local Reynolds number.</ddue:para>
+										polynomial function of the local Reynolds number. Furthermore,
+										it is possible to specify technology factors. Fuselage
+										(including tailcone upsweep drag) is incorporated as well.</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
 								<ddue:title>1.
+									&lt;fuselages&gt;
+									<ddue:legacyItalic>(optional)</ddue:legacyItalic>
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>This node contains a list of fuselages and their
+										parameters for computation with this method.</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>2.
 									&lt;wings&gt;
 									<ddue:legacyItalic>(optional)</ddue:legacyItalic>
 								</ddue:title>
 								<ddue:content>
-									<ddue:para>This node contains a list of wings and theit
+									<ddue:para>This node contains a list of wings and their
 										parameters for computation with this method.</ddue:para>
 								</ddue:content>
 							</ddue:section>
@@ -21054,6 +21132,7 @@ jonas.jepsen@dlr.de
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
 				<xsd:all>
+					<xsd:element minOccurs="0" name="fuselages" type="handbookAeroFuselagesTransitionsType"/>
 					<xsd:element minOccurs="0" name="wings" type="handbookAeroWingsTransitionsType"/>
 				</xsd:all>
 			</xsd:extension>
@@ -21108,6 +21187,101 @@ jonas.jepsen@dlr.de
 	</xsd:complexType>
 
 
+	<xsd:complexType name="handbookAeroFuselageTransitionsType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>A selected fuselage with its transition definition
+						</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:content>
+							<ddue:section>
+								<ddue:title>0. General overview</ddue:title>
+								<ddue:content>
+									<ddue:para>Parameters for calculating the viscous drag of a
+										fuselage, or (if common parameters shall be used) for all fuselages.
+									</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>1.
+									&lt;fuselageUID&gt;
+									<ddue:legacyItalic>(optional)</ddue:legacyItalic>
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>This node contains a reference to the fuselage, for
+										which the viscous drag shall be calculated. If all fuselages shall
+										be computed with common parameters, this node can be omitted.
+									</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>2.
+									&lt;relativeTransitionLocation&gt;
+									<ddue:legacyItalic>(mandatory)</ddue:legacyItalic>
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>In this subnode, the relative transition location for the fuselage is specified</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>3.
+									&lt;calculateTailConeUpsweepDrag&gt;
+									<ddue:legacyItalic>(optional)</ddue:legacyItalic>
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>This subnode is a switch. If there, it switches on the calculation of tail cone upsweep drag</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>4.
+									&lt;technologyFactor&gt;
+									<ddue:legacyItalic>(optional)</ddue:legacyItalic>
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>Additional factor for calibrating the results.</ddue:para>
+								</ddue:content>
+							</ddue:section>
+						</ddue:content>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:all>
+					<xsd:element minOccurs="0" name="wingUID" type="stringBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Reference to a wing; required, if separate
+								transition definitions for each wing are used. If missing,
+								transition definitions are the same for all wings. If used, only
+								the specified wings are calculated</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="relativeTransitionLocation" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Relative location of laminar/turbulent transition</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="calculateTailConeUpsweepDrag" type="stringBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Switch for considering tail cone upsweep drag</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="technologyFactor" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Technology factor</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:all>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
 	<xsd:complexType name="handbookAeroWingTransitionsType">
 
 		<xsd:annotation>
@@ -21145,7 +21319,7 @@ jonas.jepsen@dlr.de
 									<ddue:legacyItalic>(mandatory)</ddue:legacyItalic>
 								</ddue:title>
 								<ddue:content>
-									<ddue:para>In this subnode, the tansition regions and
+									<ddue:para>In this subnode, the transition regions and
 										parameters for this region are specified for the upper side of
 										the wing.</ddue:para>
 								</ddue:content>
@@ -21156,7 +21330,7 @@ jonas.jepsen@dlr.de
 									<ddue:legacyItalic>(mandatory)</ddue:legacyItalic>
 								</ddue:title>
 								<ddue:content>
-									<ddue:para>In this subnode, the tansition regions and
+									<ddue:para>In this subnode, the transition regions and
 										parameters for this region are specified for the lower side of
 										the wing.</ddue:para>
 								</ddue:content>
@@ -21185,6 +21359,52 @@ jonas.jepsen@dlr.de
 	</xsd:complexType>
 
 
+	<xsd:complexType name="handbookAeroFuselagesTransitionsType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>A list of fuselages for computation</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:content>
+							<ddue:section>
+								<ddue:title>0. General overview</ddue:title>
+								<ddue:content>
+									<ddue:para>A list of fuselages and their parameters for computation
+										of viscous drag. If only some fuselages are specified here, only
+										the specified fuselages will be computed. It is also possible to
+										specify only one fuselage here and to omit the reference to a fuselage
+										UID in this fuselage's subnode. Then, all fuselages are computed with
+										the specified parameters as common values.</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>1.
+									&lt;fuselage&gt;
+									<ddue:legacyItalic>(mandatory)</ddue:legacyItalic>
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>A fuselage which is selected for computation, including
+										the required parameters.</ddue:para>
+								</ddue:content>
+							</ddue:section>
+						</ddue:content>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" name="fuselage" type="handbookAeroFuselageTransitionsType"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+
 	<xsd:complexType name="handbookAeroWingsTransitionsType">
 
 		<xsd:annotation>
@@ -21199,7 +21419,7 @@ jonas.jepsen@dlr.de
 								<ddue:title>0. General overview</ddue:title>
 								<ddue:content>
 									<ddue:para>A list of wings and their parameters for computation
-										of viscous drag. if only some wings are specified here, only
+										of viscous drag. If only some wings are specified here, only
 										the specified wings will be computed. It is also possible to
 										specify only one wing here and to omit the reference to a wing
 										UID in this wing's subnode. Then, all wings are computed with
@@ -22908,7 +23128,26 @@ jonas.jepsen@dlr.de
 							</ddue:section>
 							<ddue:section>
 								<ddue:title>
-									3. &lt;wingPanelings&gt;
+									3. &lt;parallelComputation&gt;
+									<ddue:legacyItalic>(mandatoy)</ddue:legacyItalic>
+								</ddue:title>
+								<ddue:content>
+									<ddue:para>This node specifies, on how many cores the LIFTING_LINE computation
+										shall be performed in parallel:
+ 									<ddue:list class="bullet">
+											<ddue:listItem>0: Parallel computation on as many cores as available 
+											</ddue:listItem>
+											<ddue:listItem>1: Sequential computation
+											</ddue:listItem>
+											<ddue:listItem>#: Parallel computation on # cores
+											</ddue:listItem>
+										</ddue:list>
+									</ddue:para>
+								</ddue:content>
+							</ddue:section>
+							<ddue:section>
+								<ddue:title>
+									4. &lt;wingPanelings&gt;
 									<ddue:legacyItalic>(mandatoy)</ddue:legacyItalic>
 								</ddue:title>
 								<ddue:content>
@@ -22948,21 +23187,12 @@ jonas.jepsen@dlr.de
 							</xsd:simpleContent>
 						</xsd:complexType>
 					</xsd:element>
-					<xsd:element name="parallelComputation">
+					<xsd:element name="parallelComputation" type="integerBaseType">
 						<xsd:annotation>
 							<xsd:documentation>0=parallel computation on all available cores,
-								1=sequencial computation, n=parallel computation on n cores
+								1=sequencial computation, #=parallel computation on # cores
 							</xsd:documentation>
 						</xsd:annotation>
-						<xsd:complexType>
-							<xsd:simpleContent>
-								<xsd:restriction base="integerBaseType">
-									<xsd:enumeration value="0"/>
-									<xsd:enumeration value="1"/>
-									<xsd:enumeration value="2"/>
-								</xsd:restriction>
-							</xsd:simpleContent>
-						</xsd:complexType>
 					</xsd:element>
 					<xsd:element name="wingPanelings" type="liftingLineWingPanelingsType"/>
 				</xsd:all>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -2189,13 +2189,13 @@ jonas.jepsen@dlr.de
 		</xsd:complexContent>
 	</xsd:complexType>
 
-	<xsd:complexType name="aeroPerformanceMapsType">
+	<xsd:complexType name="aeroPerformanceMapsRCType">
 
 		<xsd:annotation>
 			<xsd:appinfo>
 				<sd:schemaDoc>
 					<ddue:summary>
-						<ddue:para>aeroPerformanceMapsType</ddue:para>
+						<ddue:para>aeroPerformanceMapsRCType</ddue:para>
 					</ddue:summary>
 					<ddue:remarks>
 						<ddue:para>aeroPerformanceMaps type, containing
@@ -3298,7 +3298,7 @@ jonas.jepsen@dlr.de
 								axis system!)</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsType">
+					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsRCType">
 						<xsd:annotation>
 							<xsd:documentation>Calculated aerodynamic performance maps of the
 								airfoil</xsd:documentation>
@@ -15687,7 +15687,7 @@ jonas.jepsen@dlr.de
 								axis system!)</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsType">
+					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsRCType">
 						<xsd:annotation>
 							<xsd:documentation>Calculated aerodynamic performance maps of the
 								fuselage</xsd:documentation>
@@ -18454,7 +18454,7 @@ jonas.jepsen@dlr.de
 								force and moment coefficients</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsType">
+					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsRCType">
 						<xsd:annotation>
 							<xsd:documentation>Calculated aerodynamic performance maps of the
 								full configuration</xsd:documentation>
@@ -39478,7 +39478,7 @@ jonas.jepsen@dlr.de
 								system!)</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsType">
+					<xsd:element name="aeroPerformanceMaps" type="aeroPerformanceMapsRCType">
 						<xsd:annotation>
 							<xsd:documentation>Calculated aerodynamic performance maps of the
 								wing</xsd:documentation>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -292,14 +292,14 @@ jonas.jepsen@dlr.de
                                             </ddue:listItem>
                                             <ddue:listItem>mapType="array" <ddue:para>The array is meant for multi-dimensional-arrays. Again, the values are contained in a semicolon separated list. An array is always preceded by a sequence of vectors, containing the dimensions and index values of it:</ddue:para>
                                                 <ddue:code language="XML" title=" ">&lt;machNumber mapType="vector"&gt;0.5&lt;/machNumber&gt;
-&lt;reynoldsNumber mapType="vector"&gt;10000000.;20000000.&lt;/reynoldsNumber&gt;
+&lt;altitude mapType="vector"&gt;1000.;2000.&lt;/altitude&gt;
 &lt;angleOfSideslip mapType="vector"&gt;-5.;0.;5.&lt;/angleOfSideslip&gt;
 &lt;angleOfAttack mapType="vector"&gt;1.;2.;3.;4.&lt;/angleOfAttack&gt;
 &lt;cfx mapType="array"&gt;1.;2.;3.;4.;11.;12.;13.;14.;21.;22.;23.;24.;101.;102.;103.;104.;111.;112.;113.;114.;121.;122.;123.;124.&lt;/cfx&gt;</ddue:code>
-                                                <ddue:para>In this example, the values for "cfx" are given in a way to indicate the array order: The last parameter is always varied first, then the pre-last, and then further. The array above is also shown in the following tables:</ddue:para>
+                                                <ddue:para>In this example, the values for "cfxAero" are given in a way to indicate the array order: The last parameter is always varied first, then the pre-last, and then further. The array above is also shown in the following tables:</ddue:para>
                                                 <ddue:table>
                                                     <ddue:title>
-                                                        <ddue:legacyBold>Value for cfx, Mach number: 0.5, Reynolds number: 10000000</ddue:legacyBold>
+                                                        <ddue:legacyBold>Value for cfxAero, Mach number: 0.5, altitude: 1000 m</ddue:legacyBold>
                                                     </ddue:title>
                                                     <ddue:row>
                                                         <ddue:entry/>
@@ -309,21 +309,21 @@ jonas.jepsen@dlr.de
                                                         <ddue:entry>Angle of attack = 4.°</ddue:entry>
                                                     </ddue:row>
                                                     <ddue:row>
-                                                        <ddue:entry>Angle of Yaw = -5.°</ddue:entry>
+                                                        <ddue:entry>Angle of Sideslip = -5.°</ddue:entry>
                                                         <ddue:entry>1.</ddue:entry>
                                                         <ddue:entry>2.</ddue:entry>
                                                         <ddue:entry>3.</ddue:entry>
                                                         <ddue:entry>4.</ddue:entry>
                                                     </ddue:row>
                                                     <ddue:row>
-                                                        <ddue:entry>Angle of Yaw = 0.°</ddue:entry>
+                                                        <ddue:entry>Angle of Sideslip = 0.°</ddue:entry>
                                                         <ddue:entry>11.</ddue:entry>
                                                         <ddue:entry>12.</ddue:entry>
                                                         <ddue:entry>13.</ddue:entry>
                                                         <ddue:entry>14.</ddue:entry>
                                                     </ddue:row>
                                                     <ddue:row>
-                                                        <ddue:entry>Angle of Yaw = 5.°</ddue:entry>
+                                                        <ddue:entry>Angle of Sideslip = 5.°</ddue:entry>
                                                         <ddue:entry>21.</ddue:entry>
                                                         <ddue:entry>22.</ddue:entry>
                                                         <ddue:entry>23.</ddue:entry>
@@ -332,7 +332,7 @@ jonas.jepsen@dlr.de
                                                 </ddue:table>
                                                 <ddue:table>
                                                     <ddue:title>
-                                                        <ddue:legacyBold>Value for cfx, Mach number: 0.5, Reynolds number: 20000000</ddue:legacyBold>
+                                                        <ddue:legacyBold>Value for cfxAero, Mach number: 0.5, Reynolds number: 2000 m</ddue:legacyBold>
                                                     </ddue:title>
                                                     <ddue:row>
                                                         <ddue:entry/>
@@ -342,21 +342,21 @@ jonas.jepsen@dlr.de
                                                         <ddue:entry>Angle of attack = 4.°</ddue:entry>
                                                     </ddue:row>
                                                     <ddue:row>
-                                                        <ddue:entry>Angle of Yaw = -5.°</ddue:entry>
+                                                        <ddue:entry>Angle of Sideslip = -5.°</ddue:entry>
                                                         <ddue:entry>101.</ddue:entry>
                                                         <ddue:entry>102.</ddue:entry>
                                                         <ddue:entry>103.</ddue:entry>
                                                         <ddue:entry>104.</ddue:entry>
                                                     </ddue:row>
                                                     <ddue:row>
-                                                        <ddue:entry>Angle of Yaw = 0.°</ddue:entry>
+                                                        <ddue:entry>Angle of Sideslip = 0.°</ddue:entry>
                                                         <ddue:entry>111.</ddue:entry>
                                                         <ddue:entry>112.</ddue:entry>
                                                         <ddue:entry>113.</ddue:entry>
                                                         <ddue:entry>114.</ddue:entry>
                                                     </ddue:row>
                                                     <ddue:row>
-                                                        <ddue:entry>Angle of Yaw = 5.°</ddue:entry>
+                                                        <ddue:entry>Angle of Sideslip = 5.°</ddue:entry>
                                                         <ddue:entry>121.</ddue:entry>
                                                         <ddue:entry>122.</ddue:entry>
                                                         <ddue:entry>123.</ddue:entry>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -370,6 +370,20 @@ jonas.jepsen@dlr.de
                                 </ddue:content>
                             </ddue:section>
                             <ddue:section>
+                                <ddue:title>8. Atmosphere</ddue:title>
+                                <ddue:content>
+                                    <ddue:para>At some places in CPACS, an atmosphere has to be selected (e.g. for connecting an altitude with a certein pressure or density).
+                                      Currently, CPACS does only support a single atmospheric model: The ICAO Standard Atmosphere (ISA) from 1993 (see ICAO Doc 7488/3 'MANUAL OF THE ICAO STANDARD ATMOSPHERE', third edition, 1993)
+                                      It covers temperature, pressure, density, speed of sound, dynamic viscosity and kinematic viscosity with respect to altitude.
+                                      In CPACS, 'altitude' means what is called 'geopotential altitude' (H) in the ISA reference document and is given in [m].
+                                      For details, see ISA manual, section 2.3, page E-viii f.
+                                      ISA covers a range from -5000 m to 80000 m.</ddue:para>
+                                    <ddue:para>Temperature offsets are introduced on top of the definitions in the ISA manual (which does not cover such variations). The offset model
+                                      is based upon the idea that the pressure at a fixed geopotential altitude is independent from temperature offset (pressure altitude).
+                                      The temperature offset changes only the density (following rho = p / Gas Constant / T) (and viscosity, of course)</ddue:para>
+                                </ddue:content>
+                            </ddue:section>
+                            <ddue:section>
                                 <ddue:title>CPACS 2.3.1</ddue:title>
                                 <ddue:content>
                                     <ddue:para>Release in Jul 2016</ddue:para>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -2222,7 +2222,7 @@ jonas.jepsen@dlr.de
 							performance maps incorporating elastic deformation</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element minOccurs="0" name="controlSurfaces" type="controlSurfaceDeflectionsType">
+					<xsd:element minOccurs="0" name="defaultControlSurfaceDeflections" type="controlSurfaceDeflectionsType">
 						<xsd:annotation>
 							<xsd:documentation>Default control surface setting for this AeroPerformanceMap.
 								Using this node, it is possible to define a default control surface setting

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -2000,15 +2000,30 @@ jonas.jepsen@dlr.de
 			<xsd:appinfo>
 				<sd:schemaDoc>
 					<ddue:summary>
-						<ddue:para>controlSurfacePerformanceMapType</ddue:para>
+						<ddue:para>aeroLandingGearType</ddue:para>
 					</ddue:summary>
 					<ddue:remarks>
 						<ddue:para>LandingGearPerformanceMap type, containing a delta
-							perfomance map with aerodynamic data for a landingGear. Array
-							order is: relativeDeflection min-&gt;max then angleOfAttack then
-							angleOfSideslip then reynoldsNumber then machNumber. AngleOfAttack,
-							angleOfSideslip, reynoldsNumber and machNumber are taken from the
-							basic performance map one level above.</ddue:para>
+							perfomance map with aerodynamic data for a landing gear. This
+							means that the coefficients are deltas to be added to the
+							corresponding coefficients of the base performance map. Array
+							order is (from innermost to outermost loop): relativeDeflection
+							min-&gt;max, then angleOfAttack, then angleOfSideslip, then
+							altitude, then machNumber. AngleOfAttack, angleOfSideslip,
+							altitude and machNumber are taken from the basic performance map
+							one level above. For the definition of the coefficients,
+							please refer to the description of the base performance map</ddue:para>
+						<ddue:para>LandingGearPerformanceMap type, containing a delta
+							perfomance map with aerodynamic data for a landing gear. This
+							means that the coefficients are deltas to be added to the
+							corresponding coefficients of the base performance map for a
+							specific landing gear deflection. Array order is (from innermost
+							to outermost loop): relativeDeflection min-&gt;max, then 
+							angleOfAttack, then angleOfSideslip, then altitude, then
+							machNumber. AngleOfAttack, angleOfSideslip, altitude
+							and machNumber are taken from the base performance map
+							one level above. For the definition of the coefficients,
+							please refer to the description of the base performance map</ddue:para>
 					</ddue:remarks>
 				</sd:schemaDoc>
 			</xsd:appinfo>
@@ -2024,16 +2039,16 @@ jonas.jepsen@dlr.de
 					</xsd:element>
 					<xsd:element name="relDeflection" type="stringVectorBaseType">
 						<xsd:annotation>
-							<xsd:documentation>Relative deflection of the control surface
+							<xsd:documentation>Relative deflection of the landing gear
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element minOccurs="0" name="dcfx" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfy" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfz" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmx" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmy" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmz" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfxAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfyAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfzAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmxAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmyAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmzAero" type="stringArrayBaseType"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -2068,10 +2083,10 @@ jonas.jepsen@dlr.de
 			<xsd:appinfo>
 				<sd:schemaDoc>
 					<ddue:summary>
-						<ddue:para>aeroPerformanceMapType</ddue:para>
+						<ddue:para>aeroPerformanceMapRCType</ddue:para>
 					</ddue:summary>
 					<ddue:remarks>
-						<ddue:para>AeroPerformanceMap type, containing a perfomance map
+						<ddue:para>AeroPerformanceMapRC type, containing a perfomance map
 							with aerodynamic data. Array order is: angleOfAttack min-&gt;max
 							then angleOfSideslip then reynoldsNumber then machNumber</ddue:para>
 					</ddue:remarks>
@@ -2132,7 +2147,7 @@ jonas.jepsen@dlr.de
 		</xsd:complexContent>
 	</xsd:complexType>
 
-
+  
 	<xsd:complexType name="aeroPerformanceMapType">
 
 		<xsd:annotation>
@@ -2143,11 +2158,23 @@ jonas.jepsen@dlr.de
 					</ddue:summary>
 					<ddue:remarks>
 						<ddue:para>AeroPerformanceMap type, containing a perfomance map
-							with aerodynamic data. Array order is: angleOfAttack min-&gt;max
-							then angleOfSideslip then reynoldsNumber then machNumber.</ddue:para>
-						<ddue:para>All coefficients in the aeroperformanceMap relate to
-							the CPACS coordinate system. See documentation of the
-							CPACS-Element for further information.</ddue:para>
+							with aerodynamic data of the complete aircraft in the form of
+							nondimensionalized coefficients. The force coefficients (cf?Aero)
+							are nondimensionalized by dynamic pressure and reference area,
+							the moment coefficients (cm?Aero) by dynamic pressure, reference
+							area and reference length. Reference values are stored under the
+							aircraft model's &lt;reference&gt; node. The coefficients are
+							given in the aerodynamic coordiante system (see documentation of
+							the &lt;CPACS&gt; root element for further information).</ddue:para>
+						<ddue:para>The coefficients are provided as a four-dimensional full
+							factorial matrix with the four dimensions 'Mach number', 'Altitude',
+							'Angle of sideslip' and 'angle of attack' specified each in a
+							separate vector above the coefficients. The coefficient matrices
+							are each defined as a four-dimensional nested loop with
+							angleOfAttack as innermost loop, then angleOfSideslip, then altitude
+							and last (as outermost loop) machNumber. All four dimensions have to
+							be ordered from min-&gt;max. For a more detailed description, please
+							refer to documentation of the &lt;CPACS&gt; root element.</ddue:para>
 					</ddue:remarks>
 				</sd:schemaDoc>
 			</xsd:appinfo>
@@ -2155,36 +2182,121 @@ jonas.jepsen@dlr.de
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
 				<xsd:sequence>
-					<xsd:element name="machNumber" type="stringVectorBaseType">
+					<xsd:element name="name" type="stringBaseType">
 						<xsd:annotation>
-							<xsd:documentation>Mach number</xsd:documentation>
+							<xsd:documentation>Name of the AeroPerformanceMap.
+							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element name="reynoldsNumber" type="stringVectorBaseType">
+					<xsd:element minOccurs="0" name="description" type="stringBaseType">
 						<xsd:annotation>
-							<xsd:documentation>Reynolds Number</xsd:documentation>
+							<xsd:documentation>Description of the AeroPerformanceMap.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="atmosphericModel">
+						<xsd:annotation>
+							<xsd:documentation>Atmospheric model (e.g. ISA for ICAO Standard
+								atmosphere (ISA) from 1993). For more details on atmospheric
+								models, please refer to documentation of the &lt;CPACS&gt; root
+								element.</xsd:documentation>
+						</xsd:annotation>
+						<xsd:complexType>
+							<xsd:simpleContent>
+								<xsd:restriction base="stringBaseType">
+									<xsd:enumeration value="ISA"/>
+								</xsd:restriction>
+							</xsd:simpleContent>
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="deltaTemperature" type="doubleBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Offset from temperature of the atmospheric model [K].
+								For more details on atmospheric models, please refer to documentation
+								of the &lt;CPACS&gt; root element.</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="elastic" type="aeroPerformanceMapElasticType">
+						<xsd:annotation>
+							<xsd:documentation>Conditions specifying an elastic case. Used for
+							performance maps incorporating elastic deformation</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element minOccurs="0" name="controlSurfaces" type="controlSurfaceDeflectionsType">
+						<xsd:annotation>
+							<xsd:documentation>Default control surface setting for this AeroPerformanceMap.
+								Using this node, it is possible to define a default control surface setting
+								(e.g. all slats and flaps in landing configuration), which is already included
+								in the base performance map</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="machNumber" type="stringVectorBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Vector with mach numbers [-] for the performance map.
+								Ordered from min-&gt;max</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="altitude" type="stringVectorBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Vector with altitudes [m] for the performance map.
+								Ordered from min-&gt;max</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
 					<xsd:element name="angleOfSideslip" type="stringVectorBaseType">
 						<xsd:annotation>
-							<xsd:documentation>Sideslip angle</xsd:documentation>
+							<xsd:documentation>Vector with angles of sideslip [deg] for the performance map.
+								Ordered from min-&gt;max</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
 					<xsd:element name="angleOfAttack" type="stringVectorBaseType">
 						<xsd:annotation>
-							<xsd:documentation>Angle of attack</xsd:documentation>
+							<xsd:documentation>Vector with angles of attack [deg] for the performance map.
+								Ordered from min-&gt;max</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element minOccurs="0" name="cfx" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="cfy" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="cfz" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="cmx" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="cmy" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="cmz" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="cfxAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="cfyAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="cfzAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="cmxAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="cmyAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="cmzAero" type="stringArrayBaseType"/>
 					<xsd:element minOccurs="0" name="dampingDerivatives" type="dampingDerivativesRatesType"/>
 					<xsd:element minOccurs="0" name="controlSurfaces" type="controlSurfacePerformanceMapsType"/>
 					<xsd:element minOccurs="0" name="landingGears" type="aeroLandingGearsType"/>
 				</xsd:sequence>
+				<xsd:attribute name="uID" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="aeroPerformanceMapElasticType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>aeroPerformanceMapElasticType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>This node specifies a set of conditions specifying an elastic case</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:all>
+					<xsd:element name="weightAndBalanceUID" type="stringUIDBaseType">
+						<xsd:annotation>
+							<xsd:documentation>Reference to a weight and balance case</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element name="loadFactor" type="pointType">
+						<xsd:annotation>
+							<xsd:documentation>Load factors in CPACS coordinates</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:all>
 			</xsd:extension>
 		</xsd:complexContent>
 	</xsd:complexType>
@@ -2198,7 +2310,7 @@ jonas.jepsen@dlr.de
 						<ddue:para>aeroPerformanceMapsRCType</ddue:para>
 					</ddue:summary>
 					<ddue:remarks>
-						<ddue:para>aeroPerformanceMaps type, containing
+						<ddue:para>aeroPerformanceMapsRC type, containing
 							aeroPerformanceMaps</ddue:para>
 					</ddue:remarks>
 				</sd:schemaDoc>
@@ -2208,6 +2320,30 @@ jonas.jepsen@dlr.de
 			<xsd:extension base="complexBaseType">
 				<xsd:sequence>
 					<xsd:element maxOccurs="unbounded" name="aeroPerformanceMap" type="aeroPerformanceMapRCType"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:complexType name="aeroPerformanceMapsType">
+
+		<xsd:annotation>
+			<xsd:appinfo>
+				<sd:schemaDoc>
+					<ddue:summary>
+						<ddue:para>aeroPerformanceMapsType</ddue:para>
+					</ddue:summary>
+					<ddue:remarks>
+						<ddue:para>aeroPerformanceMaps type, containing multiple
+							aeroPerformanceMaps for different cases</ddue:para>
+					</ddue:remarks>
+				</sd:schemaDoc>
+			</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexContent>
+			<xsd:extension base="complexBaseType">
+				<xsd:sequence>
+					<xsd:element minOccurs="1" maxOccurs="unbounded" name="aeroPerformanceMap" type="aeroPerformanceMapType"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -3129,7 +3265,7 @@ jonas.jepsen@dlr.de
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
 				<xsd:all>
-					<xsd:element minOccurs="0" name="aeroPerformanceMap" type="aeroPerformanceMapType"/>
+					<xsd:element minOccurs="0" name="aeroPerformanceMaps" type="aeroPerformanceMapsType"/>
 					<xsd:element minOccurs="0" name="aeroelastics" type="aeroelasticsType"/>
 					<xsd:element minOccurs="0" name="dynamicAircraftModel" type="dynamicAircraftModelAnalysisType"/>
                     <xsd:element minOccurs="0" name="flightDynamics" type="flightDynamicsAnalysisType"/>
@@ -8235,11 +8371,21 @@ jonas.jepsen@dlr.de
 					</ddue:summary>
 					<ddue:remarks>
 						<ddue:para>ControlSurfacePerformanceMap type, containing a delta
-							perfomance map with aerodynamic data for a control surface. Array
-							order is: relativeDeflection min-&gt;max then angleOfAttack then
-							angleOfSideslip then reynoldsNumber then machNumber. AngleOfAttack,
-							angleOfSideslip, reynoldsNumber and machNumber are taken from the
-							basic performance map one level above.</ddue:para>
+							perfomance map with aerodynamic data for a control surface. This
+							means that the coefficients are deltas to be added to the
+							corresponding coefficients of the base performance map for a
+							specific control surface deflection. Array order is (from innermost
+							to outermost loop): relativeDeflection min-&gt;max, then 
+							angleOfAttack, then angleOfSideslip, then altitude, then
+							machNumber. AngleOfAttack, angleOfSideslip, altitude
+							and machNumber are taken from the base performance map
+							one level above. If the base performance map does already contain
+							a default control surface setting, then the deflections specified 
+							here are added to the default deflections of the base performance
+							map. If, e.g. the base map contains a deflection of 0.3 and the
+							delta deflection is 0.5, then the delta coefficients are representing
+							a deflection from 0.3 to 0.8. For the definition of the coefficients,
+							please refer to the description of the base performance map</ddue:para>
 					</ddue:remarks>
 				</sd:schemaDoc>
 			</xsd:appinfo>
@@ -8255,16 +8401,16 @@ jonas.jepsen@dlr.de
 					</xsd:element>
 					<xsd:element name="relDeflection" type="stringVectorBaseType">
 						<xsd:annotation>
-							<xsd:documentation>Relative deflection of the control surface
-							</xsd:documentation>
+							<xsd:documentation>Vector with relative deflections [-] of the
+								control surface for the performance map. Ordered from min-&gt;max</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
-					<xsd:element minOccurs="0" name="dcfx" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfy" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfz" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmx" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmy" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmz" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfxAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfyAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfzAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmxAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmyAero" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmzAero" type="stringArrayBaseType"/>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>
@@ -10537,7 +10683,7 @@ jonas.jepsen@dlr.de
 			<xsd:appinfo>
 				<sd:schemaDoc>
 					<ddue:summary>
-						<ddue:para>Performane maps with damping derivatives</ddue:para>
+						<ddue:para>Performance maps with damping derivatives</ddue:para>
 					</ddue:summary>
 					<ddue:remarks>
 						<ddue:content>
@@ -10548,119 +10694,123 @@ jonas.jepsen@dlr.de
 										the damping derivatives. The derivatives are calculated using
 										rotational rates [rad/s], normalized by:
 										Rate*ReferenceLength/flow speed. The rotations are performed
-										around the global axis directions with the aircraft model's
+										around the CPACS axis directions with the aircraft model's
 										global reference point as origin. The damping derivative
 										performance maps are arrays consisting of semicolon separated
-										values, simular to the baseline aerodynamic performance maps.
+										values, simular to the base aerodynamic performance maps see
+										there for the description of array structure and coefficients.
+										The damping derivatives given here are deltas to be multiplied
+										with a non-dimensional rotational rate and then to be added to
+										the corresponding base performance map values. 
 									</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>1. &lt;dcfxdpstar&gt; (optional)</ddue:title>
+								<ddue:title>1. &lt;dcfxAerodpstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cfx by normalized roll rate</ddue:para>
+									<ddue:para>Change of cfxAero by normalized roll rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>2. &lt;dcfxdqstar&gt; (optional)</ddue:title>
+								<ddue:title>2. &lt;dcfxAerodqstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cfx by normalized pitch rate</ddue:para>
+									<ddue:para>Change of cfxAero by normalized pitch rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>3. &lt;dcfxdrstar&gt; (optional)</ddue:title>
+								<ddue:title>3. &lt;dcfxAerodrstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cfx by normalized yaw rate</ddue:para>
+									<ddue:para>Change of cfxAero by normalized yaw rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>4. &lt;dcfydpstar&gt; (optional)</ddue:title>
+								<ddue:title>4. &lt;dcfyAerodpstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cfy by normalized roll rate</ddue:para>
+									<ddue:para>Change of cfyAero by normalized roll rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>5. &lt;dcfydqstar&gt; (optional)</ddue:title>
+								<ddue:title>5. &lt;dcfyAerodqstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cfy by normalized pitch rate</ddue:para>
+									<ddue:para>Change of cfyAero by normalized pitch rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>6. &lt;dcfydrstar&gt; (optional)</ddue:title>
+								<ddue:title>6. &lt;dcfyAerodrstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cfy by normalized yaw rate</ddue:para>
+									<ddue:para>Change of cfyAero by normalized yaw rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>7. &lt;dcfzdpstar&gt; (optional)</ddue:title>
+								<ddue:title>7. &lt;dcfzAerodpstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cfz by normalized roll rate</ddue:para>
+									<ddue:para>Change of cfzAero by normalized roll rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>8. &lt;dcfzdqstar&gt; (optional)</ddue:title>
+								<ddue:title>8. &lt;dcfzAerodqstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cfz by normalized pitch rate</ddue:para>
+									<ddue:para>Change of cfzAero by normalized pitch rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>9. &lt;dcfzdrstar&gt; (optional)</ddue:title>
+								<ddue:title>9. &lt;dcfzAerodrstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cfz by normalized yaw rate</ddue:para>
+									<ddue:para>Change of cfzAero by normalized yaw rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>10. &lt;dcmxdpstar&gt; (optional)</ddue:title>
+								<ddue:title>10. &lt;dcmxAerodpstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cmx by normalized roll rate</ddue:para>
+									<ddue:para>Change of cmxAero by normalized roll rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>11. &lt;dcmxdqstar&gt; (optional)</ddue:title>
+								<ddue:title>11. &lt;dcmxAerodqstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cmx by normalized pitch rate</ddue:para>
+									<ddue:para>Change of cmxAero by normalized pitch rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>12. &lt;dcmxdrstar&gt; (optional)</ddue:title>
+								<ddue:title>12. &lt;dcmxAerodrstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cmx by normalized yaw rate</ddue:para>
+									<ddue:para>Change of cmxAero by normalized yaw rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>13. &lt;dcmydpstar&gt; (optional)</ddue:title>
+								<ddue:title>13. &lt;dcmyAerodpstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cmy by normalized roll rate</ddue:para>
+									<ddue:para>Change of cmyAero by normalized roll rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>14. &lt;dcmydqstar&gt; (optional)</ddue:title>
+								<ddue:title>14. &lt;dcmyAerodqstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cmy by normalized pitch rate</ddue:para>
+									<ddue:para>Change of cmyAero by normalized pitch rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>15. &lt;dcmydrstar&gt; (optional)</ddue:title>
+								<ddue:title>15. &lt;dcmyAerodrstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cmy by normalized yaw rate</ddue:para>
+									<ddue:para>Change of cmyAero by normalized yaw rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>16. &lt;dcmzdpstar&gt; (optional)</ddue:title>
+								<ddue:title>16. &lt;dcmzAerodpstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cmz by normalized roll rate</ddue:para>
+									<ddue:para>Change of cmzAero by normalized roll rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>17. &lt;dcmzdqstar&gt; (optional)</ddue:title>
+								<ddue:title>17. &lt;dcmzAerodqstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cmz by normalized pitch rate</ddue:para>
+									<ddue:para>Change of cmzAero by normalized pitch rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 							<ddue:section>
-								<ddue:title>18. &lt;dcmzdrstar&gt; (optional)</ddue:title>
+								<ddue:title>18. &lt;dcmzAerodrstar&gt; (optional)</ddue:title>
 								<ddue:content>
-									<ddue:para>Change of cmz by normalized yaw rate</ddue:para>
+									<ddue:para>Change of cmzAero by normalized yaw rate</ddue:para>
 								</ddue:content>
 							</ddue:section>
 						</ddue:content>
@@ -10671,24 +10821,24 @@ jonas.jepsen@dlr.de
 		<xsd:complexContent>
 			<xsd:extension base="complexBaseType">
 				<xsd:all>
-					<xsd:element minOccurs="0" name="dcfxdpstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfxdqstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfxdrstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfydpstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfydqstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfydrstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfzdpstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfzdqstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcfzdrstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmxdpstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmxdqstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmxdrstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmydpstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmydqstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmydrstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmzdpstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmzdqstar" type="stringArrayBaseType"/>
-					<xsd:element minOccurs="0" name="dcmzdrstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfxAerodpstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfxAerodqstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfxAerodrstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfyAerodpstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfyAerodqstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfyAerodrstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfzAerodpstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfzAerodqstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcfzAerodrstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmxAerodpstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmxAerodqstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmxAerodrstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmyAerodpstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmyAerodqstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmyAerodrstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmzAerodpstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmzAerodqstar" type="stringArrayBaseType"/>
+					<xsd:element minOccurs="0" name="dcmzAerodrstar" type="stringArrayBaseType"/>
 				</xsd:all>
 				<xsd:attribute name="uID" type="xsd:string" use="required"/>
 			</xsd:extension>


### PR DESCRIPTION
As a result of a longer discussion, this is a proposal for modifying and extending the aero performance maps. Main Points include the change from Re-No. to Altitude, the option to have multiple aero performance maps and the change from body-fixed to aerodynamic coordinates (made clear by changing the coefficients <cf?> to <cf?Aero> and <cm?> to <cm?Aero>). Further changes affect the documentation of coordinate Systems and Standard atmosphere in the <cpacs> root node and an update of toolspecific blocks for handbookAero, LIFTING_LINE and VSAERO.