### PR TITLE
Some modifications in ducts definition

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -3251,12 +3251,12 @@ marko.alder@dlr.de
                         </xsd:annotation>
                     </xsd:element>
                     <xsd:element minOccurs="0" name="reference" type="referenceType"/>
+                    <xsd:element minOccurs="0" name="ducts" type="ductsType"/>
                     <xsd:element minOccurs="0" name="fuselages" type="fuselagesType"/>
                     <xsd:element minOccurs="0" name="wings" type="wingsType"/>
                     <xsd:element minOccurs="0" name="engines" type="enginePositionsType"/>
                     <xsd:element minOccurs="0" name="enginePylons" type="enginePylonsType"/>
                     <xsd:element minOccurs="0" name="landingGears" type="landingGearsType"/>
-                    <xsd:element minOccurs="0" name="ducts" type="ductsType"/>
                     <xsd:element minOccurs="0" name="systems" type="systemsType"/>
                     <xsd:element minOccurs="0" name="genericGeometryComponents" type="genericGeometryComponentsType"/>
                     <xsd:element minOccurs="0" name="global" type="aircraftGlobalType"/>
@@ -35896,6 +35896,7 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
             <xsd:extension base="complexBaseType">
                 <xsd:sequence>
                     <xsd:element name="ductAssembly" maxOccurs="unbounded" type="ductAssemblyType"/>
+                    <xsd:element name="duct" maxOccurs="unbounded" type="ductType"/>
                 </xsd:sequence>
             </xsd:extension>
         </xsd:complexContent>
@@ -35938,7 +35939,7 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                     </xsd:element>
                     <xsd:element name="transformation" minOccurs="0" type="transformationType"/>
                     <xsd:element name="excludeObjectUIDs" minOccurs="0" type="uIDSequenceType"/>
-                    <xsd:element name="duct" maxOccurs="unbounded" type="ductType"/>
+                    <xsd:element name="ductUIDs" minOccurs="1" type="uIDSequenceType"/>
                 </xsd:sequence>
                 <xsd:attribute name="uID" type="xsd:ID" use="required"/>
             </xsd:extension>
@@ -35973,9 +35974,9 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                         </xsd:annotation>
                     </xsd:element>
                     <xsd:element name="transformation" minOccurs="0" type="transformationType"/>
+                    <xsd:element name="sections" type="fuselageSectionsType"/>
                     <xsd:element name="positionings" minOccurs="0" type="positioningsType"/>
                     <xsd:element name="segments" type="fuselageSegmentsType"/>
-                    <xsd:element name="sections" type="fuselageSectionsType"/>
                     <xsd:element minOccurs="0" name="structure" type="ductStructureType"/>
                 </xsd:all>
                 <xsd:attribute name="uID" type="xsd:ID" use="required"/>


### PR DESCRIPTION
During the implementation of ducts in TiGL (https://github.com/DLR-SC/tigl/pull/889) we made some modifications in the current ducts definition. Firstly, we now have `duct`s and `ductAssembly`s at the same level under the `ductsType` and `ductAssembly`s reference a `duct` via UID. This way, `duct`s can be reused by more than one `ductAssembly`. Finally, we reordered the elements in two `xsd:all` elements to fix some issues with the order of reading the CPACS files via the routines provided by https://github.com/RISCSoftware/cpacs_tigl_gen. 

Concretely,
 - ducts element in configuration before fuselage and wing type fixes issue in tigl
 - ducts are defined on the same level as ductAssemblies to make them reusable
 - ductAssemblies reference ducts via UID to make ducts reusable
 - sections element in ductType before segments fixes issue in tigl

addresses #768